### PR TITLE
Implement a PtyProcess class

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,16 @@ pip install -U .
 Pywinpty offers a single python wrapper around winpty library functions. This implies that using a single object (``winpty.PTY``) it is possible to access to all functionallity, as it follows:
 
 ```python
+# High level usage using `spawn`
+from winpty import PtyProcess
+
+proc = PtyProcess.spawn('python')
+proc.write('print("hello, world!")\r\n')
+proc.write('exit()\r\n')
+while proc.isalive():
+	print(proc.readline())
+
+# Low level usage using the raw `PTY` object
 from winpty import PTY
 
 # Start a new winpty-agent process of size (cols, rows)

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,6 @@ import ast
 import os
 
 # Third party imports
-from Cython.Build import cythonize
 from setuptools import Extension, find_packages, setup
 
 
@@ -39,8 +38,6 @@ try:
 except KeyError:
     library_dirs = []
 
-REQUIREMENTS = ['cython']
-
 
 ext_options = {}
 cythonize_options = {}
@@ -51,6 +48,23 @@ if os.environ.get('CYTHON_COVERAGE'):
         ('CYTHON_TRACE', '1'), ('CYTHON_TRACE_NOGIL', '1')
     ]
 
+try:
+    from Cython.Build import cythonize
+    ext_modules = cythonize([
+        Extension(
+            "winpty.cywinpty",
+            sources=["winpty/cywinpty.pyx"],
+            libraries=["winpty"],
+            include_dirs=include_dirs,
+            library_dirs=library_dirs,
+            **ext_options
+        )],
+        **cythonize_options
+    )
+except ImportError:
+    ext_modules = []
+
+
 setup(
     name='pywinpty',
     version=get_version(),
@@ -60,22 +74,10 @@ setup(
     author='Edgar Andrés Margffoy-Tuay',
     author_email='andfoy@gmail.com',
     description='Python bindings for the winpty library',
-    ext_modules=cythonize(
-        [
-            Extension(
-                "winpty.cywinpty",
-                sources=["winpty/cywinpty.pyx"],
-                libraries=["winpty"],
-                include_dirs=include_dirs,
-                library_dirs=library_dirs,
-                **ext_options
-            )
-        ],
-        **cythonize_options
-    ),
+    ext_modules=ext_modules,
     packages=find_packages(exclude=['contrib', 'docs', 'tests*']),
     include_package_data=True,
-    install_requires=REQUIREMENTS,
+    setup_requires=['Cython'],
     classifiers=[
         'Development Status :: 4 - Beta', 'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',

--- a/winpty/__init__.py
+++ b/winpty/__init__.py
@@ -15,5 +15,6 @@ from .winpty_wrapper import PTY
 # yapf: enable
 
 PTY
-VERSION_INFO = (0, 2, 2, 'dev0')
+PtyProcess
+VERSION_INFO = (0, 3, 0, 'dev0')
 __version__ = '.'.join(map(str, VERSION_INFO))

--- a/winpty/__init__.py
+++ b/winpty/__init__.py
@@ -8,6 +8,7 @@ This package provides a Cython wrapper around winpty C++ library.
 # yapf: disable
 
 # Local imports
+from .ptyprocess import PtyProcess
 from .winpty_wrapper import PTY
 
 

--- a/winpty/ptyprocess.py
+++ b/winpty/ptyprocess.py
@@ -1,0 +1,164 @@
+# -*- coding: utf-8 -*-
+
+# Standard library imports
+from shutil import which
+import codecs
+import os
+import shlex
+import subprocess
+import time
+
+# Local imports
+from .winpty_wrapper import PTY
+
+
+class PtyProcess(object):
+    """This class represents a process running in a pseudoterminal.
+
+    The main constructor is the :meth:`spawn` classmethod.
+    """
+
+    def __init__(self, proc):
+        self.proc = proc
+        self.decoder = codecs.getincrementaldecoder('utf-8')(errors='strict')
+
+    @classmethod
+    def spawn(cls, cmd, cwd=None, env=None, dimensions=(24, 80)):
+        """Start the given command in a child process in a pseudo terminal.
+
+        This does all the setting up the pty, and returns an instance of
+        PtyProcess.
+
+        Dimensions of the psuedoterminal used for the subprocess can be
+        specified as a tuple (rows, cols), or the default (24, 80) will be
+        used.
+        """
+        if isinstance(cmd, str):
+            cmd = shlex.split(cmd, posix=False)
+
+        if not isinstance(cmd, (list, tuple)):
+            raise TypeError("Expected a list or tuple for cmd, got %r" % argv)
+
+        # Shallow copy of argv so we can modify it
+        cmd = cmd[:]
+        command = cmd[0]
+        env = env or os.environ
+
+        path = env.get('PATH', os.defpath)
+        command_with_path = which(command, path=path)
+        if command_with_path is None:
+            raise FileNotFoundError(
+                'The command was not found or was not ' +
+                'executable: %s.' % command
+            )
+        command = command_with_path
+        cmd[0] = command
+        cmdline = ' ' + subprocess.list2cmdline(cmd[1:])
+        cwd = cwd or os.getcwd()
+
+        proc = PTY(dimensions[1], dimensions[0])
+
+        # Create the environemnt string.
+        envStrs = []
+        for (key, value) in env.items():
+            envStrs.append('%s=%s' % (key, value))
+        env = '\0'.join(envStrs) + '\0'
+
+        if len(cmd) == 1:
+            proc.spawn(command, cwd=cwd, env=env)
+        else:
+            proc.spawn(command, cwd=cwd, env=env, cmdline=cmdline)
+
+        inst = cls(proc)
+        inst._winsize = dimensions
+        return inst
+
+    def close(self):
+        """Close all communication process streams."""
+        if self.proc:
+            self.proc.close()
+
+    def flush(self):
+        """This does nothing. It is here to support the interface for a
+        File-like object. """
+        pass
+
+    def isatty(self):
+        """This returns True if the file descriptor is open and connected to a
+        tty(-like) device, else False."""
+        return self.isalive()
+
+    def read(self, size=1024):
+        """Read and return at most ``size`` bytes from the pty.
+        """
+        if not self.isalive():
+            raise EOFError('Pty is closed')
+
+        data = self.proc.read(size)
+        return self.decoder.decode(data, final=False)
+
+    def readline(self):
+        """Read one line from the pseudoterminal as bytes.
+
+        Can block if there is nothing to read. Raises :exc:`EOFError` if the
+        terminal was closed.
+        """
+        buf = []
+        while 1:
+            if not self.isalive():
+                return ''.join(buf)
+            ch = self.read(1)
+            if not ch:
+                time.sleep(0.1)
+            buf.append(ch)
+            if ch == '\n':
+                return ''.join(buf)
+
+    def write(self, s):
+        """Write the string ``s`` to the pseudoterminal.
+
+        Returns the number of bytes written.
+        """
+        if not self.isalive():
+            raise EOFError('Pty is closed')
+        success, nbytes = self.proc.write(s)
+        if not success:
+            raise IOError('Write failed')
+        return nbytes
+
+    def terminate(self):
+        """This forces a child process to terminate."""
+        del self.proc
+        self.proc = None
+
+    def wait(self):
+        """This waits until the child exits. This is a blocking call. This will
+        not read any data from the child.
+        """
+        while self.isalive():
+            self.readline()
+        return 0
+
+    def isalive(self):
+        """This tests if the child process is running or not. This is
+        non-blocking. If the child was terminated then this will read the
+        exitstatus or signalstatus of the child. This returns True if the child
+        process appears to be running or False if not.
+        """
+        return self.proc and self.proc.isalive()
+
+    def kill(self, sig=None):
+        """Kill the process.  This is an alias to terminate.
+        """
+        self.terminate()
+
+    def getwinsize(self):
+        """Return the window size of the pseudoterminal as a tuple (rows, cols).
+        """
+        return self._winsize
+
+    def setwinsize(self, rows, cols):
+        """Set the terminal window size of the child tty.
+        """
+        self._winsize = (rows, cols)
+        self.proc.set_size(cols, rows)

--- a/winpty/tests/test_ptyprocess.py
+++ b/winpty/tests/test_ptyprocess.py
@@ -1,0 +1,123 @@
+# -*- coding: utf-8 -*-
+"""winpty wrapper tests."""
+
+# yapf: disable
+
+# Standard library imports
+import os
+import signal
+import sys
+
+# Third party imports
+from flaky import flaky
+from winpty.ptyprocess import PtyProcess
+import pytest
+
+
+# yapf: enable
+
+
+@pytest.fixture(scope='module')
+def pty_fixture(cmd=None, env=None):
+    cmd = cmd or 'cmd'
+    return PtyProcess.spawn(cmd, env=env)
+
+
+@flaky(max_runs=4, min_passes=1)
+def test_read():
+    pty = pty_fixture()
+    loc = os.getcwd()
+    data = ''
+    while loc not in data:
+        data += pty.read()
+    pty.terminate()
+
+
+def test_write():
+    pty = pty_fixture()
+
+    text = 'Eggs, ham and spam ünicode'
+    pty.write(text)
+
+    data = ''
+    while text not in data:
+        data += pty.read()
+    pty.terminate()
+
+
+def test_isalive():
+    pty = pty_fixture()
+    pty.write('exit\r\n')
+
+    text = 'exit'
+    data = ''
+    while text not in data:
+        data += pty.read()
+
+    while pty.isalive():
+        pty.read()
+        continue
+
+    assert not pty.isalive()
+    pty.terminate()
+
+
+def test_readline():
+    env = os.environ.copy()
+    env['foo'] = 'bar'
+    pty = pty_fixture(env=env)
+    pty.write('echo %foo%\r\n')
+
+    while 'bar' not in pty.readline():
+        pass
+
+    pty.terminate()
+
+
+def test_close():
+    pty = pty_fixture()
+    pty.close()
+    assert not pty.isalive()
+    pty.terminate()
+
+
+def test_flush():
+    pty = pty_fixture()
+    pty.flush()
+    pty.terminate()
+
+
+def test_isatty():
+    pty = pty_fixture()
+    assert pty.isatty()
+    pty.terminate()
+    assert not pty.isatty()
+
+
+def test_wait():
+    pty = pty_fixture(cmd=[sys.executable, "--version"])
+    assert pty.wait() == 0
+    pty.kill()
+
+
+def test_kill():
+    pty = pty_fixture()
+    pty.kill(signal.SIGTERM)
+    assert not pty.isalive()
+
+
+def test_getwinsize():
+    pty = pty_fixture()
+    assert pty.getwinsize() == (24, 80)
+    pty.terminate()
+
+
+def test_setwinsize():
+    pty = pty_fixture()
+    pty.setwinsize(50, 110)
+    assert pty.getwinsize() == (50, 110)
+    pty.terminate()
+
+    pty = PtyProcess.spawn('cmd', dimensions=(60, 120))
+    assert pty.getwinsize() == (60, 120)
+    pty.terminate()

--- a/winpty/tests/test_winpty_wrapper.py
+++ b/winpty/tests/test_winpty_wrapper.py
@@ -58,12 +58,12 @@ def test_write():
 def test_isalive():
     pty = pty_fixture(80, 25)
     pty.write('exit\r\n')
-   
+
     text = 'exit'
     line = ''
     while text not in line:
         line += str(pty.read(), 'utf-8')
-   
+
     while pty.isalive():
         pty.read()
         continue


### PR DESCRIPTION
Fixes #63 

----
Adds a `PtyProcess` class that mimics the [PtyProcessUnicode](https://github.com/pexpect/ptyprocess/blob/a8bf13895973902631d563a271505aa50828103f/ptyprocess/ptyprocess.py#L796) class.

I intend to use this in the Octave kernel, which currently bails when the user inputs a syntax error because Octave closes the pipe.  I verified that we can avoid this behavior using `winpty`.

This can also be used in https://github.com/jupyter/win-tornado-terminals.  I had it working locally with Jupyter Notebook, but realized we couldn't pass arguments to the command (one of the things this adds).

Also adds some cleanup suggested by the checker tools.