### PR TITLE
Add a file descriptor

### DIFF
--- a/winpty/ptyprocess.py
+++ b/winpty/ptyprocess.py
@@ -24,6 +24,7 @@ class PtyProcess(object):
         assert isinstance(proc, PTY)
         self.proc = proc
         self.fd = uuid.uuid4().hex
+        self.pid = uuid.uuid4().hex
         self.decoder = codecs.getincrementaldecoder('utf-8')(errors='strict')
 
     @classmethod

--- a/winpty/ptyprocess.py
+++ b/winpty/ptyprocess.py
@@ -7,6 +7,8 @@ import os
 import shlex
 import subprocess
 import time
+import uuid
+
 
 # Local imports
 from .winpty_wrapper import PTY
@@ -19,7 +21,9 @@ class PtyProcess(object):
     """
 
     def __init__(self, proc):
+        assert isinstance(proc, PTY)
         self.proc = proc
+        self.fd = uuid.uuid4().hex
         self.decoder = codecs.getincrementaldecoder('utf-8')(errors='strict')
 
     @classmethod


### PR DESCRIPTION
This is needed for uniformity with [PtyProcessUnicode](https://github.com/pexpect/ptyprocess/blob/a8bf13895973902631d563a271505aa50828103f/ptyprocess/ptyprocess.py#L161).  I ran into this while working on notebook integration.