### PR TITLE
PR: PtyProcess Cleanup

### DIFF
--- a/winpty/cywinpty.pyx
+++ b/winpty/cywinpty.pyx
@@ -31,9 +31,12 @@ cdef class Agent:
     """
     cdef winpty.winpty_t* _c_winpty_t
     cdef HANDLE _agent_process
-    cdef int pid
+    cdef HANDLE _process
+    cdef DWORD pid
     cdef LPCWSTR conin_pipe_name
     cdef LPCWSTR conout_pipe_name
+    cdef DWORD exitstatus
+    cdef unsigned char alive
 
     def __init__(self, int cols, int rows, bint override_pipes=True,
                  int mouse_mode=winpty_constants._WINPTY_MOUSE_MODE_NONE,
@@ -72,9 +75,10 @@ cdef class Agent:
             raise RuntimeError(msg)
 
         self._agent_process = winpty.winpty_agent_process(self._c_winpty_t)
-        self.pid = GetProcessId(self._agent_process)
         self.conin_pipe_name = winpty.winpty_conin_name(self._c_winpty_t)
         self.conout_pipe_name = winpty.winpty_conout_name(self._c_winpty_t)
+        self.alive = 0
+        self.pid = 0
 
     property conin_pipe_name:
         def __get__(self):
@@ -88,6 +92,15 @@ cdef class Agent:
         def __get__(self):
             return self.pid
 
+    property exitstatus:
+        def __get__(self):
+            if self.pid == 0:
+                return None
+            if self.alive == 1:
+                self.isalive()
+            if self.alive == 1:
+                return None
+            return self.exitstatus
 
     def spawn(self, LPCWSTR appname, LPCWSTR cmdline=NULL,
               LPCWSTR cwd=NULL, LPCWSTR env=NULL):
@@ -105,7 +118,7 @@ cdef class Agent:
             raise RuntimeError(msg)
 
         cdef winpty.winpty_error_ptr_t spawn_err
-        cdef bint succ = winpty.winpty_spawn(self._c_winpty_t, spawn_config, NULL,
+        cdef bint succ = winpty.winpty_spawn(self._c_winpty_t, spawn_config, &self._process,
                                              NULL, NULL, &spawn_err)
         winpty.winpty_spawn_config_free(spawn_config)
 
@@ -115,6 +128,9 @@ cdef class Agent:
                 winpty.winpty_error_code(spawn_err))
             winpty.winpty_error_free(spawn_err)
             raise RuntimeError(msg)
+
+        self.pid = GetProcessId(self._process)
+        self.alive = 1
 
         return succ
 
@@ -138,11 +154,21 @@ cdef class Agent:
             raise RuntimeError(msg)
 
     def isalive(self):
+        """This tests if the pty process is running or not.
+        This is non-blocking.
+        """
         cdef DWORD lpExitCode
-        cdef bint succ = GetExitCodeProcess(self._agent_process, &lpExitCode)
+        cdef bint succ = GetExitCodeProcess(self._process, &lpExitCode)
+        if not succ:
+            raise RuntimeError('Could not check status')
+
         # Check for STILL_ACTIVE flag
         # https://msdn.microsoft.com/en-us/library/windows/desktop/ms683189(v=vs.85).aspx
-        return succ and lpExitCode == 259
+        alive = lpExitCode == 259
+        if not alive:
+            self.alive = 0
+            self.exitstatus = lpExitCode
+        return alive
 
     def __dealloc__(self):
         if self._c_winpty_t is not NULL:

--- a/winpty/cywinpty.pyx
+++ b/winpty/cywinpty.pyx
@@ -140,6 +140,8 @@ cdef class Agent:
     def isalive(self):
         cdef DWORD lpExitCode
         cdef bint succ = GetExitCodeProcess(self._agent_process, &lpExitCode)
+        # Check for STILL_ACTIVE flag
+        # https://msdn.microsoft.com/en-us/library/windows/desktop/ms683189(v=vs.85).aspx
         return succ and lpExitCode == 259
 
     def __dealloc__(self):

--- a/winpty/cywinpty.pyx
+++ b/winpty/cywinpty.pyx
@@ -17,6 +17,8 @@ cdef extern from "Windows.h":
     ctypedef DWORD *LPDWORD
     ctypedef LPCWSTR LPCTSTR
 
+    DWORD GetProcessId(HANDLE proc)
+
 
 cdef class Agent:
     """
@@ -65,6 +67,7 @@ cdef class Agent:
             raise RuntimeError(msg)
 
         self._agent_process = winpty.winpty_agent_process(self._c_winpty_t)
+        self.pid = GetProcessId(self._agent_process)
         self.conin_pipe_name = winpty.winpty_conin_name(self._c_winpty_t)
         self.conout_pipe_name = winpty.winpty_conout_name(self._c_winpty_t)
 
@@ -75,6 +78,7 @@ cdef class Agent:
     property conout_pipe_name:
         def __get__(self):
             return self.conout_pipe_name
+
 
     def spawn(self, LPCWSTR appname, LPCWSTR cmdline=NULL,
               LPCWSTR cwd=NULL, LPCWSTR env=NULL):

--- a/winpty/cywinpty.pyx
+++ b/winpty/cywinpty.pyx
@@ -31,6 +31,7 @@ cdef class Agent:
     """
     cdef winpty.winpty_t* _c_winpty_t
     cdef HANDLE _agent_process
+    cdef int pid
     cdef LPCWSTR conin_pipe_name
     cdef LPCWSTR conout_pipe_name
 
@@ -82,6 +83,10 @@ cdef class Agent:
     property conout_pipe_name:
         def __get__(self):
             return self.conout_pipe_name
+
+    property pid:
+        def __get__(self):
+            return self.pid
 
 
     def spawn(self, LPCWSTR appname, LPCWSTR cmdline=NULL,

--- a/winpty/cywinpty.pyx
+++ b/winpty/cywinpty.pyx
@@ -18,6 +18,10 @@ cdef extern from "Windows.h":
     ctypedef LPCWSTR LPCTSTR
 
     DWORD GetProcessId(HANDLE proc)
+    bint GetExitCodeProcess(
+      HANDLE  hProcess,
+      LPDWORD lpExitCode
+    )
 
 
 cdef class Agent:
@@ -127,6 +131,11 @@ cdef class Agent:
                 winpty.winpty_error_code(err_pointer))
             winpty.winpty_error_free(err_pointer)
             raise RuntimeError(msg)
+
+    def isalive(self):
+        cdef DWORD lpExitCode
+        cdef bint succ = GetExitCodeProcess(self._agent_process, &lpExitCode)
+        return succ and lpExitCode == 259
 
     def __dealloc__(self):
         if self._c_winpty_t is not NULL:

--- a/winpty/cywinpty.pyx
+++ b/winpty/cywinpty.pyx
@@ -17,6 +17,8 @@ cdef extern from "Windows.h":
     ctypedef DWORD *LPDWORD
     ctypedef LPCWSTR LPCTSTR
 
+    DEF STILL_ACTIVE = 259
+
     DWORD GetProcessId(HANDLE proc)
     bint GetExitCodeProcess(
       HANDLE  hProcess,
@@ -164,7 +166,7 @@ cdef class Agent:
 
         # Check for STILL_ACTIVE flag
         # https://msdn.microsoft.com/en-us/library/windows/desktop/ms683189(v=vs.85).aspx
-        alive = lpExitCode == 259
+        alive = lpExitCode == STILL_ACTIVE
         if not alive:
             self.alive = 0
             self.exitstatus = lpExitCode

--- a/winpty/ptyprocess.py
+++ b/winpty/ptyprocess.py
@@ -22,6 +22,7 @@ class PtyProcess(object):
     def __init__(self, pty):
         assert isinstance(pty, PTY)
         self.pty = pty
+        self.pid = pty.pid
         self.fd = pty.conout_pipe
         self.decoder = codecs.getincrementaldecoder('utf-8')(errors='strict')
 
@@ -168,9 +169,9 @@ class PtyProcess(object):
         return self.pty and self.pty.isalive()
 
     def kill(self, sig=None):
-        """Kill the process.  This is an alias to terminate.
+        """Kill the process with the given signal.
         """
-        self.terminate()
+        os.kill(self.pid, sig)
 
     def getwinsize(self):
         """Return the window size of the pseudoterminal as a tuple (rows, cols).

--- a/winpty/ptyprocess.py
+++ b/winpty/ptyprocess.py
@@ -256,7 +256,7 @@ class PtyProcess(object):
         if 97 <= a <= 122:
             a = a - ord('a') + 1
             byte = bytes([a])
-            return self.pty.write(byte)
+            return self.pty.write(byte.decode('utf-8')), byte
         d = {'@': 0, '`': 0,
             '[': 27, '{': 27,
             '\\': 28, '|': 28,
@@ -268,7 +268,7 @@ class PtyProcess(object):
             return 0, b''
 
         byte = bytes([d[char]])
-        return self.pty.write(byte)
+        return self.pty.write(byte.decode('utf-8')), byte
 
     def sendeof(self):
         """This sends an EOF to the child. This sends a character which causes
@@ -280,13 +280,13 @@ class PtyProcess(object):
         It is the responsibility of the caller to ensure the eof is sent at the
         beginning of a line."""
         # Send control character 4 (Ctrl-D)
-        self.pty.write('\x04')
+        self.pty.write('\x04'), '\x04'
 
     def sendintr(self):
         """This sends a SIGINT to the child. It does not require
         the SIGINT to be the first character on a line. """
         # Send control character 3 (Ctrl-C)
-        self.pty.write('\x03')
+        self.pty.write('\x03'), '\x03'
 
     def eof(self):
         """This returns True if the EOF exception was ever raised.

--- a/winpty/ptyprocess.py
+++ b/winpty/ptyprocess.py
@@ -280,13 +280,13 @@ class PtyProcess(object):
         It is the responsibility of the caller to ensure the eof is sent at the
         beginning of a line."""
         # Send control character 4 (Ctrl-D)
-        self.pty.write(b'\x04')
+        self.pty.write('\x04')
 
     def sendintr(self):
         """This sends a SIGINT to the child. It does not require
         the SIGINT to be the first character on a line. """
         # Send control character 3 (Ctrl-C)
-        self.pty.write(b'\x03')
+        self.pty.write('\x03')
 
     def eof(self):
         """This returns True if the EOF exception was ever raised.

--- a/winpty/ptyprocess.py
+++ b/winpty/ptyprocess.py
@@ -135,7 +135,7 @@ class PtyProcess(object):
             time.sleep(self.delayafterclose)
             if self.isalive():
                 if not self.terminate(force):
-                    raise PtyProcessError('Could not terminate the child.')
+                    raise IOError('Could not terminate the child.')
             self.fd = -1
             self.closed = True
             del self.pty
@@ -243,6 +243,18 @@ class PtyProcess(object):
         """Kill the process with the given signal.
         """
         os.kill(self.pid, sig)
+
+    def sendeof(self):
+        """This sends an EOF to the child. This sends a character which causes
+        the pending parent output buffer to be sent to the waiting child
+        program without waiting for end-of-line. If it is the first character
+        of the line, the read() in the user program returns 0, which signifies
+        end-of-file. This means to work as expected a sendeof() has to be
+        called at the beginning of a line. This method does not send a newline.
+        It is the responsibility of the caller to ensure the eof is sent at the
+        beginning of a line."""
+        # Send control character 4 (Ctrl-D)
+        self.proc.write(b'\x04')
 
     def getwinsize(self):
         """Return the window size of the pseudoterminal as a tuple (rows, cols).

--- a/winpty/ptyprocess.py
+++ b/winpty/ptyprocess.py
@@ -22,7 +22,7 @@ class PtyProcess(object):
     def __init__(self, pty):
         assert isinstance(pty, PTY)
         self.pty = pty
-        self.fd = id(pty)
+        self.fd = pty.conout_pipe
         self.decoder = codecs.getincrementaldecoder('utf-8')(errors='strict')
 
     @classmethod

--- a/winpty/tests/test_ptyprocess.py
+++ b/winpty/tests/test_ptyprocess.py
@@ -79,8 +79,6 @@ def test_readline():
 def test_close():
     pty = pty_fixture()
     pty.close()
-    assert pty.isalive()
-    pty.terminate()
     assert not pty.isalive()
 
 

--- a/winpty/tests/test_ptyprocess.py
+++ b/winpty/tests/test_ptyprocess.py
@@ -102,6 +102,12 @@ def test_send_control():
     assert pty.wait() != 0
 
 
+def test_send_eof():
+    cat = pty_fixture('cat')
+    cat.sendeof()
+    assert cat.wait() == 0
+
+
 def test_isatty():
     pty = pty_fixture()
     assert pty.isatty()

--- a/winpty/tests/test_ptyprocess.py
+++ b/winpty/tests/test_ptyprocess.py
@@ -54,9 +54,11 @@ def test_isalive():
     while text not in data:
         data += pty.read()
 
-    while pty.isalive():
-        pty.read()
-        continue
+    while 1:
+        try:
+            pty.read()
+        except EOFError:
+            break
 
     assert not pty.isalive()
     pty.terminate()
@@ -77,8 +79,9 @@ def test_readline():
 def test_close():
     pty = pty_fixture()
     pty.close()
-    assert not pty.isalive()
+    assert pty.isalive()
     pty.terminate()
+    assert not pty.isalive()
 
 
 def test_flush():
@@ -97,7 +100,7 @@ def test_isatty():
 def test_wait():
     pty = pty_fixture(cmd=[sys.executable, "--version"])
     assert pty.wait() == 0
-    pty.kill()
+    pty.terminate()
 
 
 def test_kill():

--- a/winpty/tests/test_ptyprocess.py
+++ b/winpty/tests/test_ptyprocess.py
@@ -88,6 +88,13 @@ def test_flush():
     pty.terminate()
 
 
+def test_intr():
+    pty = pty_fixture()
+    pty = pty_fixture(cmd=[sys.executable, 'import time; time.sleep(10)'])
+    pty.sendintr()
+    assert pty.wait() != 0
+
+
 def test_isatty():
     pty = pty_fixture()
     assert pty.isatty()

--- a/winpty/tests/test_ptyprocess.py
+++ b/winpty/tests/test_ptyprocess.py
@@ -95,6 +95,13 @@ def test_intr():
     assert pty.wait() != 0
 
 
+def test_send_control():
+    pty = pty_fixture()
+    pty = pty_fixture(cmd=[sys.executable, 'import time; time.sleep(10)'])
+    pty.sendcontrol('d')
+    assert pty.wait() != 0
+
+
 def test_isatty():
     pty = pty_fixture()
     assert pty.isatty()

--- a/winpty/tests/test_ptyprocess.py
+++ b/winpty/tests/test_ptyprocess.py
@@ -98,15 +98,22 @@ def test_isatty():
 
 
 def test_wait():
-    pty = pty_fixture(cmd=[sys.executable, "--version"])
+    pty = pty_fixture(cmd=[sys.executable, '--version'])
     assert pty.wait() == 0
-    pty.terminate()
+
+
+def test_exit_status():
+    pty = pty_fixture(cmd=[sys.executable])
+    pty.write('import sys;sys.exit(1)\r\n')
+    pty.wait()
+    assert pty.exitstatus == 1
 
 
 def test_kill():
     pty = pty_fixture()
     pty.kill(signal.SIGTERM)
     assert not pty.isalive()
+    assert pty.exitstatus == signal.SIGTERM
 
 
 def test_getwinsize():

--- a/winpty/winpty_wrapper.py
+++ b/winpty/winpty_wrapper.py
@@ -81,3 +81,10 @@ class PTY(Agent):
         """Close all communication process streams."""
         windll.kernel32.CloseHandle(self.conout_pipe)
         windll.kernel32.CloseHandle(self.conin_pipe)
+
+    def iseof(self):
+        """Check if current process streams are still open."""
+        succ = windll.kernel32.PeekNamedPipe(
+            self.conout_pipe, None, None, None, None, None
+        )
+        return not bool(succ)

--- a/winpty/winpty_wrapper.py
+++ b/winpty/winpty_wrapper.py
@@ -81,11 +81,3 @@ class PTY(Agent):
         """Close all communication process streams."""
         windll.kernel32.CloseHandle(self.conout_pipe)
         windll.kernel32.CloseHandle(self.conin_pipe)
-
-    def isalive(self):
-        """Check if current process streams are still open."""
-        err = windll.kernel32.PeekNamedPipe(
-            self.conout_pipe, None, None, None, None, None
-        )
-        alive = bool(err)
-        return alive


### PR DESCRIPTION
- Use a socket pair to read the pty output to match the posix `PtyProcess` and allow us to use [ioloop.add_handler](https://github.com/takluyver/terminado/blob/master/terminado/management.py#L164)
- Get the actual `pid` of the process so we can send signals.
- Improve detection of `isalive()` using a Windows API call
- Add exit status handling
- Clean up `EOF` handling
- Rename `self.proc` -> `self.pty`
- Add a `__del__` method to free up the open files.
- Fix `read` docstring to correctly show that it returns characters
- Add missing methods from the posix `PtyProcess`.