### PR TITLE
PR: Fix OSError on spawning of PtyProcess

### DIFF
--- a/winpty/ptyprocess.py
+++ b/winpty/ptyprocess.py
@@ -46,6 +46,8 @@ class PtyProcess(object):
         # Set up our file reader sockets.
         self._server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         address = _get_address()
+        # Socket from _get_address may still be in wait state.
+        time.sleep(self.delayafterclose * 0.1)
         self._server.bind(address)
         self._server.listen(1)
 


### PR DESCRIPTION
Fixes #86.

Initially I tried to solve this by allowing reuse of the port (via setting `setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)`) but it resulted in permission denied errors (on Windows 7).