### PR TITLE
PR: Refuse to import on Windows 7

### DIFF
--- a/winpty/winpty_wrapper.py
+++ b/winpty/winpty_wrapper.py
@@ -15,9 +15,9 @@ import os
 import sys
 
 # Refuse to import on Windows 7
-if os.name == 'nt' and sys.getwindowsversion().major == 7:
-    raise OSError('Cannot use winpty on Windows 7, '
-                  'see https://github.com/spyder-ide/pywinpty/issues/59')
+if os.name == 'nt' and sys.getwindowsversion().major <= 7:
+    raise ImportError('Cannot use winpty on Windows 7, '
+                      'see https://github.com/spyder-ide/pywinpty/issues/59')
 
 
 PY2 = sys.version_info[0] == 2

--- a/winpty/winpty_wrapper.py
+++ b/winpty/winpty_wrapper.py
@@ -16,6 +16,7 @@ import sys
 
 # Refuse to import on Windows 7
 if os.name == 'nt' and sys.getwindowsversion().major <= 7:
+    print(sys.getwindowsversion())
     raise ImportError('Cannot use winpty on Windows 7, '
                       'see https://github.com/spyder-ide/pywinpty/issues/59')
 

--- a/winpty/winpty_wrapper.py
+++ b/winpty/winpty_wrapper.py
@@ -11,7 +11,14 @@ import ctypes
 # Local imports
 from .cywinpty import Agent
 
+import os
 import sys
+
+# Refuse to import on Windows 7
+if os.name == 'nt' and sys.getwindowsversion().major == 7:
+    raise OSError('Cannot use winpty on Windows 7, '
+                  'see https://github.com/spyder-ide/pywinpty/issues/59')
+
 
 PY2 = sys.version_info[0] == 2
 


### PR DESCRIPTION
Fixes #59.

Workaround for https://github.com/spyder-ide/pywinpty/issues/59 since we can't pin down the source of the problem on Windows 7.  This prevents other libraries (like the Jupyter notebook) from attempting to use this library only to later find that it does not work.