### PR TITLE
PR: Wait (blocking) for data when using PtyProcess

### DIFF
--- a/winpty/ptyprocess.py
+++ b/winpty/ptyprocess.py
@@ -328,12 +328,11 @@ def _read_in_thread(address, pty):
     client.connect(address)
 
     while 1:
-        data = pty.read(4096)
+        data = pty.read(4096, blocking=True)
 
         if not data and not pty.isalive():
             while not data and not pty.iseof():
-                time.sleep(0.1)
-                data += pty.read(4096)
+                data += pty.read(4096, blocking=True)
 
             if not data:
                 try:

--- a/winpty/tests/test_ptyprocess.py
+++ b/winpty/tests/test_ptyprocess.py
@@ -89,14 +89,12 @@ def test_flush():
 
 
 def test_intr():
-    pty = pty_fixture()
     pty = pty_fixture(cmd=[sys.executable, 'import time; time.sleep(10)'])
     pty.sendintr()
     assert pty.wait() != 0
 
 
 def test_send_control():
-    pty = pty_fixture()
     pty = pty_fixture(cmd=[sys.executable, 'import time; time.sleep(10)'])
     pty.sendcontrol('d')
     assert pty.wait() != 0

--- a/winpty/winpty_wrapper.py
+++ b/winpty/winpty_wrapper.py
@@ -57,7 +57,7 @@ class PTY(Agent):
             None
         )
 
-    def read(self, length=1000):
+    def read(self, length=1000, blocking=False):
         """
         Read ``length`` bytes from current process output stream.
 
@@ -65,9 +65,10 @@ class PTY(Agent):
         behaves like one.
         """
         size_p = PLARGE_INTEGER(LARGE_INTEGER(0))
-        windll.kernel32.GetFileSizeEx(self.conout_pipe, size_p)
-        size = size_p[0]
-        length = min(size, length)
+        if not blocking:
+            windll.kernel32.GetFileSizeEx(self.conout_pipe, size_p)
+            size = size_p[0]
+            length = min(size, length)
         data = ctypes.create_string_buffer(length)
         if length > 0:
             ReadFile(self.conout_pipe, data, length, None, None)


### PR DESCRIPTION
This is alternative solution to the problem described at https://github.com/jupyter/terminado/issues/54 and pull request workaround https://github.com/spyder-ide/pywinpty/pull/94.

Instead of doing any `time.sleep` `PtyProcess` read thread it is simply blocking waiting for `stdout` data. When the underlyiung console process dies, console pipe gets closed so read exits as well.

#### Notes

I have tested it with `pytest` and manually using JupyterLab console.

#### Commit notes

Previously PtyProcess thread was using non-blocking calls to read which
was effectively caused high-CPU usage, which was partially mitigated
by time.sleep(0.1).

NOTE: When console process dies the pipe gets closed, causing read to
return as well.

Also, removed superfluous `pty = pty_fixture()` calls from PtyProcess
that made tests hang with blocking approach on `cmd.exe`.