### PR TITLE
Build and publish with Python 3.10 in GitHub actions.

### DIFF
--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -17,7 +17,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                PYTHON_VERSION: ["3.6", "3.7", "3.8", "3.9"]
+                PYTHON_VERSION: ["3.6", "3.7", "3.8", "3.9", "3.10"]
         steps:
             - name: Checkout branch
               uses: actions/checkout@v2

--- a/.github/workflows/windows_release.yml
+++ b/.github/workflows/windows_release.yml
@@ -15,7 +15,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                PYTHON_VERSION: ["3.6", "3.7", "3.8", "3.9"]
+                PYTHON_VERSION: ["3.6", "3.7", "3.8", "3.9", "3.10"]
         steps:
             - name: Checkout branch
               uses: actions/checkout@v2


### PR DESCRIPTION
Fixes #185

I test ran the GitHub actions on my [fork](https://github.com/joseph-roitman/pywinpty/actions) and everything seems to work fine.
I also built pywinpty in a local Miniconda environment and successfully installed the built wheel in a clean Python 3.10 installation.