### PR TITLE
Fix compile error C2664 on win32

### DIFF
--- a/src/csrc/conpty_common.cpp
+++ b/src/csrc/conpty_common.cpp
@@ -37,7 +37,7 @@ HRESULT PrepareStartupInformation(HPCON hpc, STARTUPINFOEX* psi)
 
     // Discover the size required for the list
     size_t bytesRequired;
-    InitializeProcThreadAttributeList(NULL, 1, 0, &bytesRequired);
+    InitializeProcThreadAttributeList(NULL, 1, 0, (PSIZE_T)&bytesRequired);
 
     // Allocate memory to represent the list
     si.lpAttributeList = (PPROC_THREAD_ATTRIBUTE_LIST)HeapAlloc(GetProcessHeap(), 0, bytesRequired);
@@ -47,7 +47,7 @@ HRESULT PrepareStartupInformation(HPCON hpc, STARTUPINFOEX* psi)
     }
 
     // Initialize the list memory location
-    if (!InitializeProcThreadAttributeList(si.lpAttributeList, 1, 0, &bytesRequired))
+    if (!InitializeProcThreadAttributeList(si.lpAttributeList, 1, 0, (PSIZE_T)&bytesRequired))
     {
         HeapFree(GetProcessHeap(), 0, si.lpAttributeList);
         return HRESULT_FROM_WIN32(GetLastError());


### PR DESCRIPTION
Fixes compile errors on win32 (32-bit Windows binaries):
```
    src/csrc/conpty_common.cpp(40): error C2664: 'BOOL InitializeProcThreadAttributeList(LPPROC_THREAD_ATTRIBUTE_LIST,DWORD,DWORD,PSIZE_T)': cannot convert argument 4 from 'size_t *' to 'PSIZE_T'
    src/csrc/conpty_common.cpp(40): note: Types pointed to are unrelated; conversion requires reinterpret_cast, C-style cast or function-style cast
    C:\Program Files (x86)\Windows Kits\10\include\10.0.19041.0\um\processthreadsapi.h(673): note: see declaration of 'InitializeProcThreadAttributeList'
    src/csrc/conpty_common.cpp(50): error C2664: 'BOOL InitializeProcThreadAttributeList(LPPROC_THREAD_ATTRIBUTE_LIST,DWORD,DWORD,PSIZE_T)': cannot convert argument 4 from 'size_t *' to 'PSIZE_T'
    src/csrc/conpty_common.cpp(50): note: Types pointed to are unrelated; conversion requires reinterpret_cast, C-style cast or function-style cast
    C:\Program Files (x86)\Windows Kits\10\include\10.0.19041.0\um\processthreadsapi.h(673): note: see declaration of 'InitializeProcThreadAttributeList'
```