### PR TITLE
enable building pywinpty without winpty and debug code

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -131,5 +131,7 @@ fn main() {
         .extra_warnings(false)
         .compile("winptywrapper");
 
-    println!("cargo:rustc-link-lib=dylib=winpty");
+    if winpty_enabled == "1" {
+        println!("cargo:rustc-link-lib=dylib=winpty");
+    }
 }

--- a/include/StackWalker.h
+++ b/include/StackWalker.h
@@ -1,5 +1,5 @@
 
-#ifdef DEBUG
+#if DEBUG
 #ifndef __STACKWALKER_H__
 #define __STACKWALKER_H__
 

--- a/include/common.h
+++ b/include/common.h
@@ -13,13 +13,13 @@
 #include <iostream>
 
 
-#ifdef ENABLE_WINPTY
+#if ENABLE_WINPTY
 static constexpr bool WINPTY_ENABLED = true;
 #else
 static constexpr bool WINPTY_ENABLED = false;
 #endif // ENABLE_WINPTY
 
-#ifdef ENABLE_CONPTY
+#if ENABLE_CONPTY
 static constexpr bool CONPTY_ENABLED = true;
 #else
 static constexpr bool CONPTY_ENABLED = false;

--- a/include/winpty_common.h
+++ b/include/winpty_common.h
@@ -2,7 +2,8 @@
 #include "base.h"
 
 
-#ifdef ENABLE_WINPTY
+#if ENABLE_WINPTY
+
 extern "C" {
     #include <winpty.h>
     #include <winpty_constants.h>

--- a/src/csrc/StackWalker.cpp
+++ b/src/csrc/StackWalker.cpp
@@ -82,7 +82,7 @@
  *
  **********************************************************************/
 
-#ifdef DEBUG
+#if DEBUG
 #include "StackWalker.h"
 
 #include <stdio.h>

--- a/src/csrc/conpty_common.cpp
+++ b/src/csrc/conpty_common.cpp
@@ -7,7 +7,7 @@ Native ConPTY calls.
 See: https://docs.microsoft.com/en-us/windows/console/creating-a-pseudoconsole-session
 **/
 
-#ifdef ENABLE_CONPTY
+#if ENABLE_CONPTY
 
 HRESULT SetUpPseudoConsole(HPCON* hPC, COORD size, HANDLE* inputReadSide, HANDLE* outputWriteSide,
                            HANDLE* outputReadSide, HANDLE* inputWriteSide) {

--- a/src/csrc/pty.cpp
+++ b/src/csrc/pty.cpp
@@ -1,6 +1,6 @@
 #include "pty.h"
 
-#ifdef DEBUG
+#if DEBUG
 // Debug utilities used to print a stack trace
 // In order to use it:
 // MyStackWalker sw; sw.ShowCallstack();

--- a/src/csrc/winpty_common.cpp
+++ b/src/csrc/winpty_common.cpp
@@ -1,6 +1,6 @@
 #include "winpty_common.h"
 
-#ifdef ENABLE_WINPTY
+#if ENABLE_WINPTY
 void compose_error_message(winpty_error_ptr_t err, char* tmp) {
     std::wstring err_msg = winpty_error_msg(err);
     std::wstring err_code = std::to_wstring(winpty_error_code(err));


### PR DESCRIPTION
This patch enables building pywinpty without winpty. The existing code didn't work as the ENABLE_WINPTY is defined to 0 by `build.rs` and C pre-processor considers them as defined even if the value is 0. Replacing the ifdef by if fixes this issue.