### PR TITLE
Fix an encoding issue in sendcontrol

### DIFF
--- a/winpty/ptyprocess.py
+++ b/winpty/ptyprocess.py
@@ -282,7 +282,7 @@ class PtyProcess(object):
         a = ord(char)
         if 97 <= a <= 122:
             a = a - ord('a') + 1
-            byte = str(bytes([a]))
+            byte = bytes([a]).decode("ascii")
             return self.pty.write(byte), byte
         d = {'@': 0, '`': 0,
             '[': 27, '{': 27,
@@ -294,7 +294,7 @@ class PtyProcess(object):
         if char not in d:
             return 0, ''
 
-        byte = str(bytes([d[char]]))
+        byte = bytes([d[char]]).decode("ascii")
         return self.pty.write(byte), byte
 
     def sendeof(self):


### PR DESCRIPTION
fix the bug in sendcontrol function.
let us take an example of sending ctrl+c through this function,

* the oiriginal code
```
byte = str(bytes([0x03]))
```
the byte would be r"b\x03"

* the modified code
```
byte = bytes([0x03]).decode("ascii")
```
the byte would be "\x03"
