### PR TITLE
Solve type issues

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,21 +120,21 @@ impl PyPTY {
     ///
     /// Arguments
     /// ---------
-    /// appname: bytes
-    ///     Byte string that contains the path to the application that will
+    /// appname: str
+    ///     String that contains the path to the application that will
     ///     be started.
-    /// cmdline: Optional[bytes]
-    ///     Byte string that contains the parameters to start the application,
+    /// cmdline: Optional[str]
+    ///     String that contains the parameters to start the application,
     ///     separated by whitespace.
-    /// cwd: Optional[bytes]
-    ///     Byte string that contains the working directory that the application
+    /// cwd: Optional[str]
+    ///     String that contains the working directory that the application
     ///     should have. If None, the application will inherit the current working
     ///     directory of the Python interpreter.
-    /// env: Optional[bytes]
-    ///     Byte string that contains the name and values of the environment
+    /// env: Optional[str]
+    ///     String that contains the name and values of the environment
     ///     variables that the application should have. Each (name, value) pair
     ///     should be declared as `name=value` and each pair must be separated
-    ///     by an empty byte `\0`. If None, then the application will inherit
+    ///     by an empty character `\0`. If None, then the application will inherit
     ///     the environment variables of the Python interpreter.
     ///
     /// Returns
@@ -204,24 +204,24 @@ impl PyPTY {
         }
     }
 
-    /// Read a number of bytes from the pseudoterminal output stream.
+    /// Read a length of text from the pseudoterminal output stream.
     ///
     /// Arguments
     /// ---------
     /// blocking: bool
-    ///     If True, the call will be blocked until the requested number of bytes
+    ///     If True, the call will be blocked until the requested length of string
     ///     are available to read. Otherwise, it will return an empty byte string
-    ///     if there are no available bytes to read.
+    ///     if there are no available string to read.
     ///
     /// Returns
     /// -------
-    /// output: bytes
-    ///     A byte string that contains the output of the pseudoterminal.
+    /// output: str
+    ///     A String that contains the output of the pseudoterminal.
     ///
     /// Raises
     /// ------
     /// WinptyError
-    ///     If there was an error whilst trying to read the requested number of bytes
+    ///     If there was an error whilst trying to read the requested length of string
     ///     from the pseudoterminal.
     ///
     /// Notes
@@ -245,12 +245,12 @@ impl PyPTY {
         }
     }
 
-    /// Write a byte string into the pseudoterminal input stream.
+    /// Write a string into the pseudoterminal input stream.
     ///
     /// Arguments
     /// ---------
-    /// to_write: bytes
-    ///     The byte sequence that is going to be sent to the pseudoterminal.
+    /// to_write: str
+    ///     The character sequence that is going to be sent to the pseudoterminal.
     ///
     /// Returns
     /// -------
@@ -260,7 +260,7 @@ impl PyPTY {
     /// Raises
     /// ------
     /// WinptyError
-    ///     If there was an error whilst trying to write the requested number of bytes
+    ///     If there was an error whilst trying to write the character sequence
     ///     into the pseudoterminal.
     ///
     fn write(&self, to_write: OsString, py: Python) -> PyResult<u32> {

--- a/winpty/winpty.pyi
+++ b/winpty/winpty.pyi
@@ -8,6 +8,10 @@ from typing import Optional
 # Local imports
 from .enums import Backend, Encoding, MouseMode, AgentConfig
 
+__version__: str
+
+class WinptyError(Exception):
+    ...
 
 class PTY:
     def __init__(self, cols: int, rows: int,
@@ -19,25 +23,25 @@ class PTY:
         ...
 
     def spawn(self,
-              appname: bytes,
-              cmdline: Optional[bytes] = None,
-              cwd: Optional[bytes] = None,
-              env: Optional[bytes] = None) -> bool:
+              appname: str,
+              cmdline: Optional[str] = None,
+              cwd: Optional[str] = None,
+              env: Optional[str] = None) -> bool:
         ...
 
     def set_size(self, cols: int, rows: int): ...
 
     def read(self,
              length: Optional[int] = 1000,
-             blocking: bool = False) -> bytes:
+             blocking: bool = False) -> str:
         ...
 
     def read_stderr(self,
              length: Optional[int] = 1000,
-             blocking: bool = False) -> bytes:
+             blocking: bool = False) -> str:
         ...
 
-    def write(self, to_write: bytes) -> int: ...
+    def write(self, to_write: str) -> int: ...
 
     def isalive(self) -> bool: ...
 


### PR DESCRIPTION
As mentioned in #377, the Python binding corresponding to Rust's `OsString` type is `<class 'str'>`.

In `winpty/winpty.pyi`, the parameters for `PTY.spawn`, the return values of `PTY.read/read_stderr`, and the parameters for `PTY.write` are incorrectly annotated as `bytes`, when they should actually be `str`.

While these incorrect type annotations were less problematic in the past, modern AI-powered IDEs rely heavily on Python's type system. Erroneous type hints can directly cause AI assistants to generate incorrect code.

To address this, I enabled Pylance's type checking (Standard mode) and manually resolved all type-related errors and warnings.

> Since I'm not a native English speaker, please forgive any awkward phrasing in my edits and feel free to revise them.