### PR TITLE
Update build.rs

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -53,6 +53,7 @@ fn main() {
                         let simplified_arch = match ARCH {
                             "x86_64" => "x64",
                             "arm" => "arm64",
+                            "aarch64" => "arm64",
                             _ => ARCH,
                         };
 


### PR DESCRIPTION
On a Snapdragon X Elite processor ARCH is set to aarch64 but still can execute the arm64 ConPTY binaries.