### PR TITLE
Remove deprecated actions-rs/toolchain

### DIFF
--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -24,13 +24,6 @@ jobs:
         steps:
             - name: Checkout branch
               uses: actions/checkout@v4
-            - name: Install latest Rust stable
-              uses: actions-rs/toolchain@v1
-              with:
-                toolchain: stable
-                target: x86_64-pc-windows-msvc
-                override: true
-                components: rustfmt, clippy
             - uses: nuget/setup-nuget@v2
               with:
                 nuget-version: '5.x'


### PR DESCRIPTION
https://github.com/actions-rs/toolchain is an ___archived___ repository last modified 5 years ago.

All GitHub Actions [runner images](https://github.com/actions/runner-images/tree/main) have stable Rust pre-installed.
* https://github.com/actions/runner-images/blob/main/images/windows/Windows2022-Readme.md#rust-tools