### PR TITLE
Fix typos discovered by codespell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -470,7 +470,7 @@ In this release 1 pull request was closed.
 ### Issues Closed
 
 * [Issue 126](https://github.com/spyder-ide/pywinpty/issues/126) - Release v0.5.6
-* [Issue 123](https://github.com/spyder-ide/pywinpty/issues/123) - pip install fails on Python 3.8/Windoes ([PR 125](https://github.com/spyder-ide/pywinpty/pull/125))
+* [Issue 123](https://github.com/spyder-ide/pywinpty/issues/123) - pip install fails on Python 3.8/Windows ([PR 125](https://github.com/spyder-ide/pywinpty/pull/125))
 
 In this release 2 issues were closed.
 
@@ -511,7 +511,7 @@ In this release 4 issues were closed.
 
 ### Pull Requests Merged
 
-* [PR 113](https://github.com/spyder-ide/pywinpty/pull/113) - PR: Add PYWINPTY_BLOCK envirnoment variable to disable ptyprocess read block ([110](https://github.com/spyder-ide/pywinpty/issues/110))
+* [PR 113](https://github.com/spyder-ide/pywinpty/pull/113) - PR: Add PYWINPTY_BLOCK environment variable to disable ptyprocess read block ([110](https://github.com/spyder-ide/pywinpty/issues/110))
 * [PR 112](https://github.com/spyder-ide/pywinpty/pull/112) - PR: Remove import-time verification ([111](https://github.com/spyder-ide/pywinpty/issues/111))
 * [PR 109](https://github.com/spyder-ide/pywinpty/pull/109) - PR: Fix for access violation error ([108](https://github.com/spyder-ide/pywinpty/issues/108))
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ on pytest-lazy-fixture, which can be installed via pip:
 pip install pytest pytest-lazy-fixture flaky
 ```
 
-All the tests can be exceuted using the following command
+All the tests can be executed using the following command
 
 ```bash
 python runtests.py

--- a/runtests.py
+++ b/runtests.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-"""Script used to run pytest programatically."""
+"""Script used to run pytest programmatically."""
 
 # Standard library imports
 import argparse

--- a/winpty/enums.py
+++ b/winpty/enums.py
@@ -50,5 +50,5 @@ class AgentConfig:
 
     # Do output color escape sequences.  These escapes are output by default,
     # but are suppressed with WINPTY_FLAG_PLAIN_OUTPUT.
-    # Use this flag to reenable them.
+    # Use this flag to re-enable them.
     WINPTY_FLAG_COLOR_ESCAPES = 0x4

--- a/winpty/ptyprocess.py
+++ b/winpty/ptyprocess.py
@@ -97,7 +97,7 @@ class PtyProcess(object):
         proc = PTY(dimensions[1], dimensions[0],
                    backend=backend)
 
-        # Create the environemnt string.
+        # Create the environment string.
         envStrs = []
         for (key, value) in env.items():
             envStrs.append('%s=%s' % (key, value))


### PR DESCRIPTION
https://pypi.org/project/codespell

% `codespell`
```
./CHANGELOG.md:473: Windoes ==> Windows
./CHANGELOG.md:514: envirnoment ==> environment
./README.md:119: exceuted ==> executed
./runtests.py:3: programatically ==> programmatically
./winpty/enums.py:53: reenable ==> re-enable
./winpty/ptyprocess.py:100: environemnt ==> environment
```
% `codespell --write-changes`

    

