### PR TITLE
Resolve the issue of outdated winpty.pyi

### DIFF
--- a/winpty/ptyprocess.py
+++ b/winpty/ptyprocess.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 # Standard library imports
-import codecs
 import os
 import shlex
 import signal
@@ -351,7 +350,7 @@ def _read_in_thread(address, pty: PTY, blocking: bool):
 
     while 1:
         try:
-            data = pty.read(blocking=blocking) or b'0011Ignore'
+            data = pty.read(blocking=blocking) or '0011Ignore'
             try:
                 client.send(bytes(data, 'utf-8'))
             except socket.error:

--- a/winpty/winpty.pyi
+++ b/winpty/winpty.pyi
@@ -6,53 +6,37 @@
 from typing import Optional
 
 # Local imports
-from .enums import Backend, Encoding, MouseMode, AgentConfig
+from .enums import MouseMode, AgentConfig
 
 __version__: str
 
-class WinptyError(Exception):
-    ...
+class WinptyError(Exception): ...
 
 class PTY:
-    def __init__(self, cols: int, rows: int,
-                 backend: Optional[int] = None,
-                 encoding: Optional[str] = Encoding.UTF8,
-                 mouse_mode: int = MouseMode.WINPTY_MOUSE_MODE_NONE,
-                 timeout: int = 30000,
-                 agent_config: int = AgentConfig.WINPTY_FLAG_COLOR_ESCAPES):
-        ...
-
-    def spawn(self,
-              appname: str,
-              cmdline: Optional[str] = None,
-              cwd: Optional[str] = None,
-              env: Optional[str] = None) -> bool:
-        ...
-
+    def __init__(
+        self,
+        cols: int,
+        rows: int,
+        backend: Optional[int] = None,
+        mouse_mode: int = MouseMode.WINPTY_MOUSE_MODE_NONE,
+        timeout: int = 30000,
+        agent_config: int = AgentConfig.WINPTY_FLAG_COLOR_ESCAPES,
+    ): ...
+    def spawn(
+        self,
+        appname: str,
+        cmdline: Optional[str] = None,
+        cwd: Optional[str] = None,
+        env: Optional[str] = None,
+    ) -> bool: ...
     def set_size(self, cols: int, rows: int): ...
-
-    def read(self,
-             length: Optional[int] = 1000,
-             blocking: bool = False) -> str:
-        ...
-
-    def read_stderr(self,
-             length: Optional[int] = 1000,
-             blocking: bool = False) -> str:
-        ...
-
+    def read(self, blocking: bool = False) -> str: ...
     def write(self, to_write: str) -> int: ...
-
     def isalive(self) -> bool: ...
-
     def get_exitstatus(self) -> Optional[int]: ...
-
     def iseof(self) -> bool: ...
-
-    def cancel_io() -> bool: ...
-
+    def cancel_io(self) -> bool: ...
     @property
     def pid(self) -> Optional[int]: ...
-
     @property
     def fd(self) -> Optional[int]: ...


### PR DESCRIPTION
The changes made to `src/lib.rs` on July 5, 2025, caused the interface definitions in `winpty.pyi` to significantly diverge from the actual implementation.

This PR addresses the mismatch between `winpty.pyi` and the real interface by:

1. Adding the missing `self` parameter to `cancel_io()`.
2. Removing the non-existent method `read_stderr`.
3. Removing the unused `length` parameter from the `read()` method.
4. Removing the non-existent `encoding` parameter from `__init__()`.
5. General code cleanup and formatting improvements.

Additionally, this PR fixes minor type-related issues in `ptyprocess.py`:

1. Removing the unused import `import codecs`.
2. Changing the byte literal `b'0011Ignore'` to the string `'0011Ignore'` to prevent a potential `TypeError: encoding without a string argument`.