### PR TITLE
Add PyPI links

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,8 @@ authors = [
 maintainers = [
   {name = "Edgar Margffoy", email = "andfoy@gmail.com"}
 ]
+urls.Changelog = "https://github.com/andfoy/pywinpty/blob/main/CHANGELOG.md"
+urls.Repository = "https://github.com/andfoy/pywinpty"
 
 [build-system]
 requires = ["maturin>=1.1,<2.0"]


### PR DESCRIPTION
I noticed that the PyPI page for the project was currently lacking any links to the project’s source or similar. This PR adds two useful links, which will be rendered with relevant icons on PyPI, as can be seen here on one of my projects: https://pypi.org/project/tprof/ .