### PR TITLE
Remove unnecessary finally statement

### DIFF
--- a/winpty/ptyprocess.py
+++ b/winpty/ptyprocess.py
@@ -362,8 +362,7 @@ def _read_in_thread(address, pty: PTY, blocking: bool):
                     client.send(b'')
                 except socket.error:
                     pass
-                finally:
-                    break
+                break
 
             call += 1
         except Exception as e:


### PR DESCRIPTION
Fix #554 
In this case, we don't need finally at all.
```python
            if pty.iseof():
                try:
                    client.send(b'')
                except socket.error:
                    pass
                break
```
If there is no exception, the `break` will be executed.
Else if the exception is `socket.error` or child, then the `break` will be executed.
Else if the exception is `Exception` or a child, it will be caught by `except Exception as e:` and a break will be executed there.
Else function is stop now.

Thus, the behavior is equivalent to the old one.
