### PR TITLE
CI: bump action versions and add cargo/conda/pip caches

### DIFF
--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -24,9 +24,16 @@ jobs:
         steps:
             - name: Checkout branch
               uses: actions/checkout@v6
-            - uses: nuget/setup-nuget@v2
+            - uses: nuget/setup-nuget@v4
               with:
                 nuget-version: '5.x'
+
+            # Cache cargo registry/git index and target/ between runs.
+            - name: Cache cargo + target
+              uses: Swatinem/rust-cache@v2
+              with:
+                key: ${{ matrix.PYTHON_VERSION }}
+
             - name: Remove free-threaded suffix from version
               env:
                 PYTHON_VERSION: ${{ matrix.PYTHON_VERSION }}
@@ -39,13 +46,22 @@ jobs:
                 fi
                 echo "PYTHON_VERSION_NONSUFFIX=$PYTHON_VERSION_NONSUFFIX" >> $GITHUB_ENV
             - name: Install miniconda
-              uses: conda-incubator/setup-miniconda@v3
+              uses: conda-incubator/setup-miniconda@v4
               with:
-                auto-update-conda: true
+                auto-update-conda: false
                 miniforge-version: latest
                 channels: conda-forge/label/python_rc,conda-forge
                 conda-remove-defaults: "true"
                 python-version: ${{ env.PYTHON_VERSION_NONSUFFIX }}
+                use-mamba: true
+            # Cache the conda env so `conda install winpty` becomes a no-op
+            # on warm cache hits. Key on the Python variant so free-threaded
+            # builds don't collide with the regular ones.
+            - name: Cache conda env
+              uses: actions/cache@v4
+              with:
+                path: ~/miniconda3/envs/test
+                key: ${{ runner.os }}-conda-test-py${{ matrix.PYTHON_VERSION }}-winpty-v1
             - name: Reinstall free-threaded Python
               if: ${{ endsWith(matrix.PYTHON_VERSION, 't') }}
               shell: bash -l {0}
@@ -57,6 +73,13 @@ jobs:
             - name: Install winpty
               shell: bash -l {0}
               run: conda install -y winpty
+            # Cache pip's wheel cache so re-downloading maturin/pytest/etc
+            # short-circuits to the wheel cache.
+            - name: Cache pip wheels
+              uses: actions/cache@v4
+              with:
+                path: ~/AppData/Local/pip/Cache
+                key: ${{ runner.os }}-pip-py${{ matrix.PYTHON_VERSION }}-v1
             - name: Install build/test dependencies
               shell: bash -l {0}
               run: pip install maturin toml pytest flaky

--- a/.github/workflows/windows_build_arm.yml
+++ b/.github/workflows/windows_build_arm.yml
@@ -24,9 +24,13 @@ jobs:
         steps:
             - name: Checkout branch
               uses: actions/checkout@v6
-            - uses: nuget/setup-nuget@v2
+            - uses: nuget/setup-nuget@v4
               with:
                 nuget-version: '5.x'
+            - name: Cache cargo + target
+              uses: Swatinem/rust-cache@v2
+              with:
+                key: arm-${{ matrix.PYTHON_VERSION }}
             - name: Remove free-threaded suffix from version
               env:
                 PYTHON_VERSION: ${{ matrix.PYTHON_VERSION }}

--- a/.github/workflows/windows_release.yml
+++ b/.github/workflows/windows_release.yml
@@ -20,7 +20,7 @@ jobs:
             - name: Checkout branch
               uses: actions/checkout@v6
 
-            - uses: nuget/setup-nuget@v2
+            - uses: nuget/setup-nuget@v4
               with:
                 nuget-version: '5.x'
             - name: Remove free-threaded suffix from version
@@ -35,7 +35,7 @@ jobs:
                 fi
                 echo "PYTHON_VERSION_NONSUFFIX=$PYTHON_VERSION_NONSUFFIX" >> $GITHUB_ENV
             - name: Install miniconda
-              uses: conda-incubator/setup-miniconda@v3
+              uses: conda-incubator/setup-miniconda@v4
               with:
                 auto-update-conda: true
                 miniforge-version: latest

--- a/.github/workflows/windows_release_arm.yml
+++ b/.github/workflows/windows_release_arm.yml
@@ -20,7 +20,7 @@ jobs:
         steps:
             - name: Checkout branch
               uses: actions/checkout@v6
-            - uses: nuget/setup-nuget@v2
+            - uses: nuget/setup-nuget@v4
               with:
                 nuget-version: '5.x'
             - name: Remove free-threaded suffix from version


### PR DESCRIPTION
## Summary

Workflow updates that supersede the two open dependabot bumps (#568, #569) and cut CI wall-clock on warm-cache runs.

### Action version bumps (closes #568, #569)

- \`nuget/setup-nuget\` v2 → v4 (build + release, x64 + arm64).
- \`conda-incubator/setup-miniconda\` v3 → v4 (build + release, x64).

### Caching for the x64 build workflow

- \`Swatinem/rust-cache@v2\` keyed on the Python matrix entry, so each variant gets its own cache slot.
- \`actions/cache@v4\` on \`~/miniconda3/envs/test\` — \`conda install winpty\` becomes a no-op on warm cache. Also flipped \`auto-update-conda: false\` and \`use-mamba: true\`.
- \`actions/cache@v4\` on the pip wheel cache so reinstalling maturin/pytest/etc. short-circuits to wheels.

### Caching for the arm64 build workflow

- \`Swatinem/rust-cache@v2\` keyed on \`arm-<python>\`. The arm path doesn't use conda or the pip user cache so those caches don't apply.

### Release workflows

Action version bumps only — caching adds risk for little benefit since releases run once per version.

## Expected savings

Per-matrix-entry, warm-cache:
- Cargo compile: ~90-120s saved by rust-cache (pyo3 + winpty-rs are sizable)
- Conda env setup + winpty install: ~60s saved
- Pip wheel downloads: ~10-20s saved

Stacked across 7 matrix entries × 2 workflows, this should bring the slowest jobs from ~9 minutes to ~3-4 minutes.

## Stacks logically on

- #567 (public NuGet config)
- #571 (cargo upgrades + drop Python 3.9)

No conflicts expected — different lines.